### PR TITLE
Enable basic linter checks

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: lint
+lint:
+	golangci-lint run
+


### PR DESCRIPTION
This surfaces some unreachable code, unused functions and a lot of unchecked errors.

The housekeep function in particular tripped me up when I was debugging. It 'fails' with a `redis.Nil` response. It's not clear if that's an issue or just how the Lua scripts are/redis is responding.

This adds lint errors inline in PR's too. [Like so](https://github.com/barry-hennessy/redis-sync-fanout-queue-go/pull/1/files).

We can add [more linters](https://golangci-lint.run/usage/linters) of course; this is just the defaults. Some useful ones to look at:
 - contextcheck
 - gochecknoglobals
 - gofmt/gofumpt
 - goimports